### PR TITLE
fix: linter issue

### DIFF
--- a/.github/linters/.prettierrc.yml
+++ b/.github/linters/.prettierrc.yml
@@ -1,0 +1,14 @@
+printWidth: 80
+tabWidth: 2
+useTabs: false
+semi: false
+singleQuote: true
+quoteProps: as-needed
+jsxSingleQuote: false
+trailingComma: none
+bracketSpacing: true
+bracketSameLine: true
+arrowParens: avoid
+proseWrap: always
+htmlWhitespaceSensitivity: css
+endOfLine: lf 

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,8 @@ inputs:
   enable-comments-proxy:
     description: |
       Enable Comments Proxy Server to create comments on GitHub PRs.
-      This is required when the action is invoked in a PR from a forked repository.
+      This is required when the action is invoked in a PR from a forked 
+      repository.
     default: false
     required: false
 


### PR DESCRIPTION
https://github.com/safedep/vet-action/actions/runs/13902819963/job/38898577566

We have linter issues: one reason could be difference in .prettierrc config file in local and super-linter github action. as locally we dont have any pretttier issue. So this pr introduces prettier config file for super-linter which matches local. 