### PR TITLE
Fix: linter GitHub Action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,6 +10,8 @@ on:
   schedule:
     - cron: '31 7 * * 3'
 
+permissions: read-all
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -20,6 +20,10 @@ jobs:
       - name: Checkout
         id: checkout
         uses: actions/checkout@v4
+        with:
+          # super-linter needs the full git history to get the
+          # list of files that changed across commits
+          fetch-depth: 0
 
       - name: Setup Node.js
         id: setup-node
@@ -34,13 +38,17 @@ jobs:
 
       - name: Lint Codebase
         id: super-linter
-        uses: super-linter/super-linter/slim@v5
+        uses: super-linter/super-linter/slim@v7.3.0
+
         env:
           DEFAULT_BRANCH: main
           FILTER_REGEX_EXCLUDE: (dist|__tests__)/**/*
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TYPESCRIPT_DEFAULT_STYLE: prettier
+          ENABLE_GITHUB_ACTIONS_STEP_SUMMARY: true
           VALIDATE_ALL_CODEBASE: true
+          VALIDATE_JSON: false
           VALIDATE_JAVASCRIPT_STANDARD: false
+          VALIDATE_TYPESCRIPT_STANDARD: false
+          VALIDATE_GIT_COMMITLINT: false
           VALIDATE_BASH: false
           VALIDATE_JSCPD: false

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ malicious OSS dependencies using policy as code based guardrails.
 > GitHub actions workflow. Look at [Setup Instructions](#setup-instructions) for
 > step by step guide on how to integrate `vet` in your GitHub repository
 
-TLDR; add this GitHub action to vet your changed dependencies during pull
+TLDR; add this GitHub Action to vet your changed dependencies during pull
 request
 
 ```yaml

--- a/script/release
+++ b/script/release
@@ -22,8 +22,8 @@ latest_tag=$(git describe --tags "$(git rev-list --tags --max-count=1)")
 
 # if the latest_tag is empty, then there are no tags - let the user know
 if [[ -z "$latest_tag" ]]; then
-    echo -e "No tags found (yet) - continue to create your first tag and push it"
-    latest_tag="[unknown]"
+	echo -e "No tags found (yet) - continue to create your first tag and push it"
+	latest_tag="[unknown]"
 fi
 
 echo -e "The latest release tag is: ${BLUE}${latest_tag}${OFF}"
@@ -31,10 +31,10 @@ read -r -p 'New Release Tag (vX.X.X format): ' new_tag
 
 tag_regex='v[0-9]+\.[0-9]+\.[0-9]+$'
 if echo "$new_tag" | grep -q -E "$tag_regex"; then
-    echo -e "Tag: ${BLUE}$new_tag${OFF} is valid"
+	echo -e "Tag: ${BLUE}$new_tag${OFF} is valid"
 else
-    echo -e "Tag: ${BLUE}$new_tag${OFF} is ${RED}not valid${OFF} (must be in vX.X.X format)"
-    exit 1
+	echo -e "Tag: ${BLUE}$new_tag${OFF} is ${RED}not valid${OFF} (must be in vX.X.X format)"
+	exit 1
 fi
 
 git tag -a "$new_tag" -m "$new_tag Release"


### PR DESCRIPTION
Fix for the broken linter action  #103

- updated super-linter action to v7.3.0 
- set fetch-depth to 0 in linter.yml as required by super-linter
- fixes based on linter failures
  - update README to address NATURAL_LANGUAGE linter errors
  - change spaces to tabs in script/release to address SHELL_SHFMT linter errors
  - add default read-all permission to CodeQL action to address GITHUB_ACTIONS linter errors
- disabled linters for TYPESCRIPT_STANDARD andJSON
    - TYPESCRIPT_ES, TYPESCRIPT_PRETTIER, JSON_PRETTIER are enabled which is sufficient
- enabled super-linter summaries.

