### PR TITLE
fix: exceptions file input is not handled in push events

### DIFF
--- a/src/vet.ts
+++ b/src/vet.ts
@@ -150,6 +150,12 @@ export class Vet {
 
     this.applyScanExclusions(vetFinalScanArgs)
 
+    // Check if exceptionsFile is provided
+    if (this.config.exceptionFile) {
+      core.info(`Using exceptions file: ${this.config.exceptionFile}`)
+      vetFinalScanArgs.push('--exceptions', this.config.exceptionFile)
+    }
+
     await this.runVet(vetFinalScanArgs)
 
     if (!fs.existsSync(vetSarifReportPath)) {


### PR DESCRIPTION
test data, exception file with package `mem-llm`

:red_circle:  Before this patch, we can see in the logs, that the exceptions file is not applied and package (mem-llm) is still there in logs: https://github.com/k9exp/vet-action-issue-verify/actions/runs/21681244202/job/62516006906

-- After Patch

:green_circle:  Now are are applying the exception file and there is no existance of `mem-llm`: https://github.com/k9exp/vet-action-issue-verify/actions/runs/21682382992/job/62520151041

